### PR TITLE
Fixing some enums that have changed between qt5 qt6

### DIFF
--- a/gr-qtgui/lib/spectrumdisplayform.ui
+++ b/gr-qtgui/lib/spectrumdisplayform.ui
@@ -66,7 +66,7 @@
       <string>FFT Size:</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
      </property>
      <property name="wordWrap">
       <bool>false</bool>
@@ -94,7 +94,7 @@
         <string>Window:</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
        </property>
        <property name="wordWrap">
         <bool>false</bool>
@@ -193,10 +193,10 @@
             </size>
            </property>
            <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
+            <enum>QFrame::Shape::NoFrame</enum>
            </property>
            <property name="frameShadow">
-            <enum>QFrame::Plain</enum>
+            <enum>QFrame::Shadow::Plain</enum>
            </property>
           </widget>
          </item>
@@ -259,7 +259,7 @@
               <string>Average</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignCenter</set>
+              <set>Qt::AlignmentFlag::AlignCenter</set>
              </property>
              <property name="wordWrap">
               <bool>false</bool>
@@ -279,7 +279,7 @@
            <item row="1" column="2">
             <spacer name="horizontalSpacer_2">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -328,10 +328,10 @@
           <bool>true</bool>
          </property>
          <property name="focusPolicy">
-          <enum>Qt::ClickFocus</enum>
+          <enum>Qt::FocusPolicy::ClickFocus</enum>
          </property>
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="valid" stdset="0">
           <bool>true</bool>
@@ -363,10 +363,10 @@
           </size>
          </property>
          <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
+          <enum>QFrame::Shape::NoFrame</enum>
          </property>
          <property name="frameShadow">
-          <enum>QFrame::Plain</enum>
+          <enum>QFrame::Shadow::Plain</enum>
          </property>
         </widget>
        </item>
@@ -382,10 +382,10 @@
           <bool>true</bool>
          </property>
          <property name="focusPolicy">
-          <enum>Qt::ClickFocus</enum>
+          <enum>Qt::FocusPolicy::ClickFocus</enum>
          </property>
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="valid" stdset="0">
           <bool>true</bool>
@@ -485,10 +485,10 @@
           </size>
          </property>
          <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
+          <enum>QFrame::Shape::NoFrame</enum>
          </property>
          <property name="frameShadow">
-          <enum>QFrame::Plain</enum>
+          <enum>QFrame::Shadow::Plain</enum>
          </property>
         </widget>
        </item>
@@ -508,10 +508,10 @@
           </size>
          </property>
          <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
+          <enum>QFrame::Shape::StyledPanel</enum>
          </property>
          <property name="frameShadow">
-          <enum>QFrame::Raised</enum>
+          <enum>QFrame::Shadow::Raised</enum>
          </property>
         </widget>
        </item>
@@ -546,5 +546,229 @@
   <include location="local">qwt_slider.h</include>
  </includes>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>MaxHoldCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>SpectrumDisplayForm</receiver>
+   <slot>maxHoldCheckBox_toggled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>22</x>
+     <y>324</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>MaxHoldResetBtn</sender>
+   <signal>clicked()</signal>
+   <receiver>SpectrumDisplayForm</receiver>
+   <slot>maxHoldResetBtn_clicked()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>107</x>
+     <y>324</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>MinHoldCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>SpectrumDisplayForm</receiver>
+   <slot>minHoldCheckBox_toggled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>22</x>
+     <y>349</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>MinHoldResetBtn</sender>
+   <signal>clicked()</signal>
+   <receiver>SpectrumDisplayForm</receiver>
+   <slot>minHoldResetBtn_clicked()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>107</x>
+     <y>349</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>WindowComboBox</sender>
+   <signal>activated(int)</signal>
+   <receiver>SpectrumDisplayForm</receiver>
+   <slot>windowTypeChanged(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>UseRFFrequenciesCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>SpectrumDisplayForm</receiver>
+   <slot>useRFFrequenciesCB(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>WaterfallMaximumIntensitySlider</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>SpectrumDisplayForm</receiver>
+   <slot>waterfallMaximumIntensityChangedCB(double)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>217</x>
+     <y>44</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>WaterfallMinimumIntensitySlider</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>SpectrumDisplayForm</receiver>
+   <slot>waterfallMinimumIntensityChangedCB(double)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>217</x>
+     <y>349</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>FFTSizeComboBox</sender>
+   <signal>currentTextChanged(QString)</signal>
+   <receiver>SpectrumDisplayForm</receiver>
+   <slot>fftComboBoxSelectedCB(QString)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>WaterfallAutoScaleBtn</sender>
+   <signal>clicked()</signal>
+   <receiver>SpectrumDisplayForm</receiver>
+   <slot>waterfallAutoScaleBtnCB()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>22</x>
+     <y>349</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>WaterfallIntensityComboBox</sender>
+   <signal>activated(int)</signal>
+   <receiver>SpectrumDisplayForm</receiver>
+   <slot>waterfallIntensityColorTypeChanged(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>92</x>
+     <y>44</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>SpectrumTypeTab</sender>
+   <signal>currentChanged(int)</signal>
+   <receiver>SpectrumDisplayForm</receiver>
+   <slot>tabChanged(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>314</x>
+     <y>189</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>316</x>
+     <y>217</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>AvgLineEdit</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>SpectrumDisplayForm</receiver>
+   <slot>avgLineEdit_valueChanged(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>604</x>
+     <y>421</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>328</x>
+     <y>260</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>maxHoldCheckBox_toggled(bool)</slot>
+  <slot>maxHoldResetBtn_clicked()</slot>
+  <slot>minHoldCheckBox_toggled(bool)</slot>
+  <slot>minHoldResetBtn_clicked()</slot>
+  <slot>windowTypeChanged(int)</slot>
+  <slot>useRFFrequenciesCB(bool)</slot>
+  <slot>waterfallMaximumIntensityChangedCB(double)</slot>
+  <slot>waterfallMinimumIntensityChangedCB(double)</slot>
+  <slot>fftComboBoxSelectedCB(QString)</slot>
+  <slot>waterfallAutoScaleBtnCB()</slot>
+  <slot>waterfallIntensityColorTypeChanged(int)</slot>
+  <slot>tabChanged(int)</slot>
+  <slot>avgLineEdit_valueChanged(int)</slot>
+ </slots>
 </ui>

--- a/gr-qtgui/python/qtgui/compass.py
+++ b/gr-qtgui/python/qtgui/compass.py
@@ -14,9 +14,9 @@ import numpy
 from gnuradio import gr
 import pmt
 
-from qtpy.QtCore import Signal, Property, Qt
+from qtpy.QtCore import Signal, Property, Qt, QPoint
 from qtpy.QtWidgets import QFrame, QWidget, QVBoxLayout, QHBoxLayout, QLabel, QSizePolicy
-from qtpy.QtGui import QPainter, QPalette, QFont, QFontMetricsF, QPen, QPolygon, QColor, QBrush, QPoint
+from qtpy.QtGui import QPainter, QPalette, QFont, QFontMetricsF, QPen, QPolygon, QColor, QBrush
 
 NeedleFull = 1
 NeedleIndicator = 0

--- a/gr-qtgui/python/qtgui/dialcontrol.py
+++ b/gr-qtgui/python/qtgui/dialcontrol.py
@@ -11,7 +11,7 @@
 
 from qtpy import QtWidgets
 from qtpy.QtWidgets import QFrame, QVBoxLayout, QLabel
-from qtpy.QtCore import AlignCenter, QSize
+from qtpy.QtCore import Qt, QSize
 from gnuradio import gr
 import pmt
 
@@ -33,7 +33,7 @@ class LabeledDialControl(QFrame):
         self.scaleFactor = scaleFactor
         self.lbl = lbl
         self.lblcontrol = QLabel(lbl, self)
-        self.lblcontrol.setAlignment(AlignCenter)
+        self.lblcontrol.setAlignment(Qt.AlignCenter)
 
         if self.showvalue:
             textstr = self.buildTextStr(defaultvalue)
@@ -47,7 +47,7 @@ class LabeledDialControl(QFrame):
 
         layout.addWidget(self.numberControl)
 
-        layout.setAlignment(AlignCenter)
+        layout.setAlignment(Qt.AlignCenter)
         self.setLayout(layout)
         self.show()
 

--- a/gr-qtgui/python/qtgui/dialgauge.py
+++ b/gr-qtgui/python/qtgui/dialgauge.py
@@ -10,7 +10,7 @@
 #
 
 import sys
-from qtpy.QtCore import AlignCenter, AlignVCenter
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QFrame, QHBoxLayout, QVBoxLayout, QLabel
 from qtpy.QtGui import QPainter, QColor, QPen, QFont, QFontMetricsF
 
@@ -37,7 +37,7 @@ class LabeledDialGauge(QFrame):
         self.isFloat = isFloat
 
         self.lblcontrol = QLabel(lbl, self)
-        self.lblcontrol.setAlignment(AlignCenter)
+        self.lblcontrol.setAlignment(Qt.AlignCenter)
 
         # For whatever reason, the progressbar doesn't show the number in the bar if it's
         # vertical, only if it's horizontal
@@ -62,7 +62,7 @@ class LabeledDialGauge(QFrame):
             if position == 2 or position == 4:
                 layout.addWidget(self.lblcontrol)
 
-        layout.setAlignment(AlignCenter | AlignVCenter)
+        layout.setAlignment(Qt.AlignCenter | Qt.AlignVCenter)
         self.setLayout(layout)
 
         self.show()

--- a/gr-qtgui/python/qtgui/digitalnumbercontrol.py
+++ b/gr-qtgui/python/qtgui/digitalnumbercontrol.py
@@ -9,7 +9,7 @@
 #
 #
 
-from qtpy.QtCore import Signal, QSize, QRect, AlignCenter, AlignVCenter, AlignRight, SolidPattern
+from qtpy.QtCore import Signal, QSize, QRect, Qt
 from qtpy.QtWidgets import QFrame, QVBoxLayout, QLabel
 from qtpy.QtGui import QPainter, QPixmap, QFont, QFontMetrics, QBrush, QColor
 
@@ -52,7 +52,7 @@ class LabeledDigitalNumberControl(QFrame):
             self.hasLabel = False
 
         layout.addWidget(self.numberControl)
-        layout.setAlignment(AlignCenter | AlignVCenter)
+        layout.setAlignment(Qt.AlignCenter | Qt.AlignVCenter)
         self.setLayout(layout)
         self.show()
 
@@ -298,7 +298,7 @@ class DigitalNumberControl(QFrame):
         size = self.size()
         brush = QBrush()
         brush.setColor(self.background_color)
-        brush.setStyle(SolidPattern)
+        brush.setStyle(Qt.SolidPattern)
         rect = QRect(2, 2, size.width() - 4, size.height() - 4)
         painter.fillRect(rect, brush)
 
@@ -318,7 +318,7 @@ class DigitalNumberControl(QFrame):
 
         rect = QRect(0, 0, size.width() - 4, size.height())
 
-        painter.drawText(rect, AlignRight + AlignVCenter, textstr)
+        painter.drawText(rect, Qt.AlignRight + Qt.AlignVCenter, textstr)
 
 
 class MsgDigitalNumberControl(gr.sync_block, LabeledDigitalNumberControl):

--- a/gr-qtgui/python/qtgui/graphicitem.py
+++ b/gr-qtgui/python/qtgui/graphicitem.py
@@ -9,7 +9,7 @@
 #
 #
 
-from qtpy.QtCore import KeepAspectRatio, QSize
+from qtpy.QtCore import Qt, QSize
 from qtpy.QtWidgets import QLabel
 from qtpy.QtGui import QPixmap, QPainter
 
@@ -147,7 +147,7 @@ class GrGraphicItem(gr.sync_block, QLabel):
                         w = newOverlay.width()
                         h = newOverlay.height()
                         newOverlay = newOverlay.scaled(int(w * scale), int(h * scale),
-                                                       KeepAspectRatio)
+                                                       Qt.AspectRatioMode.KeepAspectRatio)
                     painter.drawPixmap(
                         curOverlay['x'], curOverlay['y'], newOverlay)
                 except Exception as e:
@@ -190,9 +190,9 @@ class GrGraphicItem(gr.sync_block, QLabel):
             w = super().width()
             h = super().height()
 
-            self.pixmap = self.originalPixmap.scaled(w, h, KeepAspectRatio)
+            self.pixmap = self.originalPixmap.scaled(w, h,  Qt.AspectRatioMode.KeepAspectRatio)
         elif self.fixedSize and self.setWidth > 0 and self.setHeight > 0:
             self.pixmap = self.originalPixmap.scaled(self.setWidth, self.setHeight,
-                                                     KeepAspectRatio)
+                                                     Qt.AspectRatioMode.KeepAspectRatio)
 
         self.updateGraphic()

--- a/gr-qtgui/python/qtgui/levelgauge.py
+++ b/gr-qtgui/python/qtgui/levelgauge.py
@@ -12,7 +12,7 @@
 from threading import Lock
 import sys
 
-from qtpy.QtCore import Signal, AlignCenter, AlignVCenter, Vertical, Horizontal
+from qtpy.QtCore import Signal, Qt
 from qtpy.QtWidgets import QFrame, QHBoxLayout, QVBoxLayout, QLabel, QProgressBar
 from qtpy.QtGui import QColor, QPalette
 
@@ -42,7 +42,7 @@ class LabeledLevelGauge(QFrame):
         self.scaleFactor = scaleFactor
 
         self.lblcontrol = QLabel(lbl, self)
-        self.lblcontrol.setAlignment(AlignCenter)
+        self.lblcontrol.setAlignment(Qt.AlignCenter)
 
         # For whatever reason, the progressbar doesn't show the number in the bar if it's
         # vertical, only if it's horizontal
@@ -68,7 +68,7 @@ class LabeledLevelGauge(QFrame):
             if position == 2 or position == 4:
                 layout.addWidget(self.lblcontrol)
 
-        layout.setAlignment(AlignCenter | AlignVCenter)
+        layout.setAlignment(Qt.AlignCenter | Qt.AlignVCenter)
         self.setLayout(layout)
 
         self.show()
@@ -141,9 +141,9 @@ class LevelGauge(QProgressBar):
         super().setMaximum(maxValue)
 
         if isVertical:
-            super().setOrientation(Vertical)
+            super().setOrientation(Qt.Orientation.Vertical)
         else:
-            super().setOrientation(Horizontal)
+            super().setOrientation(Qt.Orientation.Horizontal)
 
     def onUpdateInt(self, new_value):
         if new_value > super().maximum():

--- a/gr-qtgui/python/qtgui/msgcheckbox.py
+++ b/gr-qtgui/python/qtgui/msgcheckbox.py
@@ -10,7 +10,7 @@
 #
 
 from qtpy import QtWidgets
-from qtpy.QtCore import AlignTop, AlignLeft, AlignBottom, AlignRight, AlignCenter, AlignVCenter
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QFrame, QVBoxLayout
 
 from gnuradio import gr
@@ -56,18 +56,18 @@ class MsgCheckBox(gr.sync_block, QFrame):
         layout.addWidget(self.chkBox)
 
         if alignment == 1:
-            halign = AlignCenter
+            halign = Qt.AlignCenter
         elif alignment == 2:
-            halign = AlignLeft
+            halign = Qt.AlignLeft
         else:
-            halign = AlignRight
+            halign = Qt.AlignRight
 
         if valignment == 1:
-            valign = AlignVCenter
+            valign = Qt.AlignVCenter
         elif valignment == 2:
-            valign = AlignTop
+            valign = Qt.AlignTop
         else:
-            valign = AlignBottom
+            valign = Qt.AlignBottom
 
         layout.setAlignment(halign | valign)
         self.setLayout(layout)


### PR DESCRIPTION

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->
Some imports and enums between qt5 and qt6 have changed.
These changes are fixed here.


## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Run 
make test
in gnuradio/build/gr-qtgui

