### PR TITLE
Adopt qtgui-*.yml files for Qt6, modify the genrator template

### DIFF
--- a/gr-qtgui/grc/qtgui_appbackground.block.yml
+++ b/gr-qtgui/grc/qtgui_appbackground.block.yml
@@ -23,7 +23,6 @@ parameters:
     hide: 'part'
 
 templates:
-    imports: import PyQt5
     make: |-
         None
         if "${relBackgroundColor}" != 'default':

--- a/gr-qtgui/grc/qtgui_ber_sink_b.block.yml
+++ b/gr-qtgui/grc/qtgui_ber_sink_b.block.yml
@@ -323,7 +323,7 @@ inputs:
 
 templates:
     imports: |-
-        import sip
+        from qtpy import sip
         import numpy
     make: |-
         <%

--- a/gr-qtgui/grc/qtgui_check_box.block.yml
+++ b/gr-qtgui/grc/qtgui_check_box.block.yml
@@ -50,7 +50,7 @@ templates:
         ${win} = Qt.QCheckBox("${no_quotes(label,repr(id))}")
         self._${id}_choices = {True: ${true}, False: ${false}}
         self._${id}_choices_inv = dict((v,k) for k,v in self._${id}_choices.items())
-        self._${id}_callback = lambda i: Qt.QMetaObject.invokeMethod(${win}, "setChecked", Qt.Q_ARG("bool", self._${id}_choices_inv[i]))
+        self._${id}_callback = lambda i: QtCore.QMetaObject.invokeMethod(${win}, "setChecked", QtCore.Q_ARG("bool", self._${id}_choices_inv[i]))
         self._${id}_callback(self.${id})
         ${win}.stateChanged.connect(lambda i: self.set_${id}(self._${id}_choices[bool(i)]))
         ${gui_hint() % win}

--- a/gr-qtgui/grc/qtgui_chooser.block.yml
+++ b/gr-qtgui/grc/qtgui_chooser.block.yml
@@ -177,7 +177,7 @@ templates:
             radio_button = Qt.QRadioButton(_label)
             self._${id}_box.addWidget(radio_button)
             self._${id}_button_group.addButton(radio_button, i)
-        self._${id}_callback = lambda i: Qt.QMetaObject.invokeMethod(self._${id}_button_group, "updateButtonChecked", Qt.Q_ARG("int", self._${id}_options.index(i)))
+        self._${id}_callback = lambda i: QtCore.QMetaObject.invokeMethod(self._${id}_button_group, "updateButtonChecked", QtCore.Q_ARG("int", self._${id}_options.index(i)))
         self._${id}_callback(self.${id})
         self._${id}_button_group.buttonClicked[int].connect(
             lambda i: self.set_${id}(self._${id}_options[i]))

--- a/gr-qtgui/grc/qtgui_const_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_const_sink_x.block.yml
@@ -395,7 +395,7 @@ inputs:
 
 templates:
     imports: |-
-        import sip
+        from qtpy import sip
     callbacks:
     - set_update_time(${update_time})
     - self.${id}.set_trigger_mode(${tr_mode}, ${tr_slope}, ${tr_level}, ${tr_chan},

--- a/gr-qtgui/grc/qtgui_edit_box_msg.block.yml
+++ b/gr-qtgui/grc/qtgui_edit_box_msg.block.yml
@@ -53,7 +53,7 @@ outputs:
 
 templates:
     imports: |-
-        import sip
+        from qtpy import sip
     make: |-
         <%
             win = 'self._%s_win'%id

--- a/gr-qtgui/grc/qtgui_entry.block.yml
+++ b/gr-qtgui/grc/qtgui_entry.block.yml
@@ -40,15 +40,15 @@ templates:
     var_make: self.${id} = ${id} = ${value}
     callbacks:
     - self.set_${id}(${value})
-    - Qt.QMetaObject.invokeMethod(self._${id}_line_edit, "setText", Qt.Q_ARG("QString",
+    - QtCore.QMetaObject.invokeMethod(self._${id}_line_edit, "setText", QtCore.Q_ARG("QString",
         ${type.str}(${id})))
     make: |-
         <%
             win = 'self._%s_tool_bar'%id
         %>
-        ${win} = Qt.QToolBar(self)
-        ${win}.addWidget(Qt.QLabel("${no_quotes(label,repr(id))}" + ": "))
-        self._${id}_line_edit = Qt.QLineEdit(str(self.${id}))
+        ${win} = QtWidgets.QToolBar(self)
+        ${win}.addWidget(QtWidgets.QLabel("${no_quotes(label,repr(id))}" + ": "))
+        self._${id}_line_edit = QtWidgets.QLineEdit(str(self.${id}))
         self._${id}_tool_bar.addWidget(self._${id}_line_edit)
         self._${id}_line_edit.${entry_signal}.connect(
             lambda: self.set_${id}(${type.conv}(str(self._${id}_line_edit.text()))))

--- a/gr-qtgui/grc/qtgui_eye_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_eye_sink_x.block.yml
@@ -928,7 +928,7 @@ inputs:
 
 templates:
     imports: |-
-        import sip
+        from qtpy import sip
 
     callbacks:
     - set_time_domain_axis(${min}, ${max})

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -405,7 +405,7 @@ asserts:
 
 templates:
     imports: |-
-        import sip
+        from qtpy import sip
 
     callbacks:
     - set_frequency_range(${fc}, ${bw})

--- a/gr-qtgui/grc/qtgui_histogram_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_histogram_sink_x.block.yml
@@ -359,7 +359,7 @@ inputs:
 
 templates:
     imports: |-
-        import sip
+        from qtpy import sip
     callbacks:
     - set_update_time(${update_time})
     - set_bins(${bins})

--- a/gr-qtgui/grc/qtgui_label.block.yml
+++ b/gr-qtgui/grc/qtgui_label.block.yml
@@ -38,7 +38,7 @@ templates:
     var_make: self.${id} = ${id} = ${value}
     callbacks:
     - self.set_${id}(${value})
-    - Qt.QMetaObject.invokeMethod(self._${id}_label, "setText", Qt.Q_ARG("QString",
+    - QtCore.QMetaObject.invokeMethod(self._${id}_label, "setText", QtCore.Q_ARG("QString",
         str(self._${id}_formatter(${id}))))
     make: |-
         <%

--- a/gr-qtgui/grc/qtgui_matrix_sink.block.yml
+++ b/gr-qtgui/grc/qtgui_matrix_sink.block.yml
@@ -3,7 +3,7 @@ label: QT GUI Matrix Sink
 
 templates:
   imports: |-
-    import sip
+    from qtpy import sip
 
   make: |-
     <%

--- a/gr-qtgui/grc/qtgui_number_sink.block.yml
+++ b/gr-qtgui/grc/qtgui_number_sink.block.yml
@@ -238,7 +238,7 @@ inputs:
 
 templates:
     imports: |-
-        import sip
+        from qtpy import sip
     callbacks:
     - set_update_time(${update_time})
     - set_average(${avg})

--- a/gr-qtgui/grc/qtgui_range.block.yml
+++ b/gr-qtgui/grc/qtgui_range.block.yml
@@ -64,7 +64,7 @@ asserts:
 - ${start <= stop}
 
 templates:
-    imports: from PyQt5 import QtCore
+    imports: from qtpy import QtCore
     var_make: self.${id} = ${id} = ${value}
     callbacks:
     - self.set_${id}(${value})

--- a/gr-qtgui/grc/qtgui_rfnoc_f15_display.block.yml
+++ b/gr-qtgui/grc/qtgui_rfnoc_f15_display.block.yml
@@ -69,7 +69,7 @@ outputs:
 
 
 templates:
-  imports: import sip
+  imports: from qtpy import sip
   make: |-
     <%
         win = 'self._%s_win' % id

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -110,7 +110,7 @@ asserts:
 
 templates:
     imports: |-
-        import sip
+        from qtpy import sip
     callbacks:
     - set_frequency_range(${fc}, ${bw})
     make: |-

--- a/gr-qtgui/grc/qtgui_time_raster_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_raster_x.block.yml
@@ -245,7 +245,7 @@ inputs:
 
 templates:
     imports: |-
-        import sip
+        from qtpy import sip
     callbacks:
     - set_num_rows(${nrows})
     - set_num_cols(${ncols})

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml
@@ -998,7 +998,7 @@ inputs:
 
 templates:
     imports: |-
-        import sip
+        from qtpy import sip
     
     callbacks:
     - set_update_time(${update_time})

--- a/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
+++ b/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
@@ -301,7 +301,7 @@ outputs:
 
 templates:
     imports: |-
-        import sip
+        from qtpy import sip
     callbacks:
     - set_update_time(${update_time})
     - set_x_axis(${x_start}, ${x_step})

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -258,7 +258,7 @@ asserts:
 
 templates:
     imports: |-
-        import sip
+        from qtpy import sip
         
     callbacks:
     - set_frequency_range(${fc}, ${bw})

--- a/gr-qtgui/lib/CMakeLists.txt
+++ b/gr-qtgui/lib/CMakeLists.txt
@@ -8,7 +8,7 @@
 ########################################################################
 # Setup the QT file generations stuff
 ########################################################################
-
+message(STATUS "QT_DEFAULT_VERSION " ${QT_DEFAULT_MAJOR_VERSION})
 set(QTGUI_SOURCES
     DisplayPlot.cc
     FrequencyDisplayPlot.cc
@@ -227,5 +227,9 @@ if(MSVC)
 endif(MSVC)
 
 if(BUILD_SHARED_LIBS)
-    gr_library_foo(gnuradio-qtgui Qwt Qt5Widgets)
+    if(QT_DEFAULT_MAJOR_VERSION EQUAL 5)
+        gr_library_foo(gnuradio-qtgui Qwt Qt5Widgets)
+    elseif(QT_DEFAULT_MAJOR_VERSION EQUAL 6)
+        gr_library_foo(gnuradio-qtgui Qwt Qt6Widgets)
+    endif() 
 endif()

--- a/gr-qtgui/lib/eyedisplaysform.cc
+++ b/gr-qtgui/lib/eyedisplaysform.cc
@@ -161,7 +161,7 @@ void EyeDisplaysForm::mousePressEvent(QMouseEvent* e)
         for (unsigned int i = 0; i < d_nplots; ++i) {
             d_lines_menu[i]->setTitle(d_displays_plot[i]->title().text());
         }
-        d_menu->exec(e->globalPos());
+        d_menu->exec(e->globalPosition().toPoint());
     }
 }
 

--- a/gr-qtgui/python/qtgui/dialgauge.py
+++ b/gr-qtgui/python/qtgui/dialgauge.py
@@ -10,7 +10,7 @@
 #
 
 import sys
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, QRect
 from qtpy.QtWidgets import QFrame, QHBoxLayout, QVBoxLayout, QLabel
 from qtpy.QtGui import QPainter, QColor, QPen, QFont, QFontMetricsF
 
@@ -133,7 +133,7 @@ class DialGauge(QFrame):
         startAngle = int(round(self.startAngle * self.degScaler, 0))
         endAngle = int(round(endAngle * self.degScaler, 0))
 
-        rect = QtCore.QRect(self.halfPenWidth, self.halfPenWidth, size.width() - self.penWidth,
+        rect = QRect(self.halfPenWidth, self.halfPenWidth, size.width() - self.penWidth,
                             size.height() - self.penWidth)
 
         # Set up the painting canvass

--- a/gr-qtgui/python/qtgui/distanceradar.py
+++ b/gr-qtgui/python/qtgui/distanceradar.py
@@ -13,7 +13,7 @@ import sys
 from qtpy import QtWidgets
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 
 from gnuradio import gr

--- a/gr-qtgui/python/qtgui/ledindicator.py
+++ b/gr-qtgui/python/qtgui/ledindicator.py
@@ -11,7 +11,7 @@
 
 from qtpy.QtWidgets import QFrame, QHBoxLayout, QVBoxLayout, QLabel
 from qtpy.QtGui import QPainter, QBrush, QColor, QPen, QFontMetricsF, QRadialGradient
-from qtpy.QtCore import Qt as Qtc, QPoint
+from qtpy.QtCore import Qt as Qtc, QPointF
 
 from gnuradio import gr
 import pmt
@@ -118,7 +118,7 @@ class LEDIndicator(QFrame):
 
         center_x = int(size.width() / 2)
         center_y = int(size.height() / 2)
-        centerpoint = QPoint(center_x, center_y)
+        centerpoint = QPointF(center_x, center_y)
 
         radius = smallest_dim
 

--- a/gr-qtgui/python/qtgui/range.py.cmakein
+++ b/gr-qtgui/python/qtgui/range.py.cmakein
@@ -68,9 +68,9 @@ class QEngValidator(QtGui.QValidator):
             if re.match(self.re, s):
                 self.parent.setStyleSheet("background-color: yellow;"
                                           "color: black")
-                return (QtGui.QValidator.Intermediate, s, pos)
+                return (QtGui.QValidator.State.Intermediate, s, pos)
             else:
-                return (QtGui.QValidator.Invalid, s, pos)
+                return (QtGui.QValidator.State.Invalid, s, pos)
 
         if self.max is not None and val > self.max:
             self.parent.setStyleSheet("background-color: yellow;"
@@ -81,7 +81,7 @@ class QEngValidator(QtGui.QValidator):
         else:
             self.parent.setStyleSheet("")
 
-        return (QtGui.QValidator.Acceptable, s, pos)
+        return (QtGui.QValidator.State.Acceptable, s, pos)
 
     def fixup(self, s):
         pass
@@ -171,7 +171,7 @@ class RangeWidget(QtWidgets.QWidget):
             # Setup the slider
             # self.setFocusPolicy(QtCore.Qt.NoFocus)
             self.setRange(0, int(ranges.nsteps - 1))
-            self.setTickPosition(2)
+            self.setTickPosition(QtWidgets.QSlider.TickPosition.TicksAbove)
             self.setSingleStep(1)
             self.range = ranges
             self.orientation = orientation

--- a/gr-qtgui/python/qtgui/util.py.cmakein
+++ b/gr-qtgui/python/qtgui/util.py.cmakein
@@ -14,7 +14,7 @@
 from gnuradio import gr
 
 def check_set_qss():
-    app = QtWidgets.qApp
+    app = QtWidgets.QApplication
     qssfile = gr.prefs().get_string("qtgui", "qss", "")
     if(len(qssfile) > 0):
         try:

--- a/grc/blocks/options.block.yml
+++ b/grc/blocks/options.block.yml
@@ -144,7 +144,7 @@ templates:
         import sys
         import signal
         % if generate_options == 'qt_gui':
-        from PyQt5 import Qt
+        from qtpy import QtCore
         % endif
         % if not generate_options.startswith('hb'):
         from argparse import ArgumentParser

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -25,9 +25,12 @@
 ##Create Imports
 ########################################################
 % if generate_options in ['qt_gui','hb_qt_gui']:
-from PyQt5 import Qt
+from qtpy import QtWidgets
+from qtpy import QtWidgets as Qt
+from qtpy import QtGui
 from gnuradio import qtgui
 %endif
+
 % for imp in imports:
 ##${imp.replace("  # grc-generated hier_block", "")}
 ${imp}
@@ -72,30 +75,30 @@ def snippets_${section}(tb):
     param_str = ', '.join(['self'] + ['%s=%s'%(param.name, param.templates.render('make')) for param in parameters])
 %>\
 % if generate_options == 'qt_gui':
-class ${class_name}(gr.top_block, Qt.QWidget):
+class ${class_name}(gr.top_block, QtWidgets.QWidget):
 
     def __init__(${param_str}):
         gr.top_block.__init__(self, "${title}", catch_exceptions=${catch_exceptions})
-        Qt.QWidget.__init__(self)
+        QtWidgets.QWidget.__init__(self)
         self.setWindowTitle("${title}")
         qtgui.util.check_set_qss()
         try:
-            self.setWindowIcon(Qt.QIcon.fromTheme('gnuradio-grc'))
+            self.setWindowIcon(QtGui.QIcon.fromTheme('gnuradio-grc'))
         except BaseException as exc:
             print(f"Qt GUI: Could not set Icon: {str(exc)}", file=sys.stderr)
-        self.top_scroll_layout = Qt.QVBoxLayout()
+        self.top_scroll_layout = QtWidgets.QVBoxLayout()
         self.setLayout(self.top_scroll_layout)
-        self.top_scroll = Qt.QScrollArea()
-        self.top_scroll.setFrameStyle(Qt.QFrame.NoFrame)
+        self.top_scroll = QtWidgets.QScrollArea()
+        self.top_scroll.setFrameStyle(QtWidgets.QFrame.NoFrame)
         self.top_scroll_layout.addWidget(self.top_scroll)
         self.top_scroll.setWidgetResizable(True)
-        self.top_widget = Qt.QWidget()
+        self.top_widget = QtWidgets.QWidget()
         self.top_scroll.setWidget(self.top_widget)
-        self.top_layout = Qt.QVBoxLayout(self.top_widget)
-        self.top_grid_layout = Qt.QGridLayout()
+        self.top_layout = QtWidgets.QVBoxLayout(self.top_widget)
+        self.top_grid_layout = QtWidgets.QGridLayout()
         self.top_layout.addLayout(self.top_grid_layout)
 
-        self.settings = Qt.QSettings("gnuradio/flowgraphs", "${class_name}")
+        self.settings = QtCore.QSettings("gnuradio/flowgraphs", "${class_name}")
 
         try:
             geometry = self.settings.value("geometry")
@@ -122,7 +125,7 @@ class ${class_name}(gr.top_block):
 
 
 % if generate_options == 'hb_qt_gui':
-class ${class_name}(gr.hier_block2, Qt.QWidget):
+class ${class_name}(gr.hier_block2, QtWidgets.QWidget):
 % else:
 class ${class_name}(gr.hier_block2):
 % endif
@@ -150,9 +153,9 @@ gr.io_signature.makev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}
     % endfor
     % if generate_options == 'hb_qt_gui':
 
-        Qt.QWidget.__init__(self)
-        self.top_layout = Qt.QVBoxLayout()
-        self.top_grid_layout = Qt.QGridLayout()
+        QtWidgets.QWidget.__init__(self)
+        self.top_layout = QtWidgets.QVBoxLayout()
+        self.top_grid_layout = QtWidgets.QGridLayout()
         self.top_layout.addLayout(self.top_grid_layout)
         self.setLayout(self.top_layout)
     % endif
@@ -230,7 +233,7 @@ gr.io_signature.makev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}
 % if generate_options == 'qt_gui':
 
     def closeEvent(self, event):
-        self.settings = Qt.QSettings("gnuradio/flowgraphs", "${class_name}")
+        self.settings = QtCore.QSettings("gnuradio/flowgraphs", "${class_name}")
         self.settings.setValue("geometry", self.saveGeometry())
         self.stop()
         self.wait()
@@ -332,7 +335,7 @@ def main(top_block_cls=${class_name}, options=None):
     % endif
     % if generate_options == 'qt_gui':
 
-    qapp = Qt.QApplication(sys.argv)
+    qapp = QtWidgets.QApplication(sys.argv)
 
     tb = top_block_cls(${ ', '.join(params_eq_list) })
     ${'snippets_main_after_init(tb)' if snippets['main_after_init'] else ''}
@@ -350,12 +353,12 @@ def main(top_block_cls=${class_name}, options=None):
         tb.stop()
         tb.wait()
         ${'snippets_main_after_stop(tb)' if snippets['main_after_stop'] else ''}
-        Qt.QApplication.quit()
+        QtWidgets.QApplication.quit()
 
     signal.signal(signal.SIGINT, sig_handler)
     signal.signal(signal.SIGTERM, sig_handler)
 
-    timer = Qt.QTimer()
+    timer = QtCore.QTimer()
     timer.start(500)
     timer.timeout.connect(lambda: None)
 


### PR DESCRIPTION
Update of the qtgui-*.yml files to qt6

Tested with all qtgui python examples in gr-qtgui the example directory with F40 and F41
The test_distanceradar example requires matplotlib >= 3.10.1