### PR TITLE
Adapt for PyQt and Qt Version 6.11

### DIFF
--- a/gr-qtgui/grc/qtgui_check_box.block.yml
+++ b/gr-qtgui/grc/qtgui_check_box.block.yml
@@ -47,7 +47,7 @@ templates:
         <%
             win = '_%s_check_box'%id
         %>
-        ${win} = Qt.QCheckBox("${no_quotes(label,repr(id))}")
+        ${win} = QtWidgets.QCheckBox("${no_quotes(label,repr(id))}")
         self._${id}_choices = {True: ${true}, False: ${false}}
         self._${id}_choices_inv = dict((v,k) for k,v in self._${id}_choices.items())
         self._${id}_callback = lambda i: QtCore.QMetaObject.invokeMethod(${win}, "setChecked", QtCore.Q_ARG("bool", self._${id}_choices_inv[i]))

--- a/gr-qtgui/grc/qtgui_chooser.block.yml
+++ b/gr-qtgui/grc/qtgui_chooser.block.yml
@@ -89,8 +89,8 @@ parameters:
 -   id: orient
     label: Orientation
     dtype: enum
-    default: Qt.QVBoxLayout
-    options: [Qt.QHBoxLayout, Qt.QVBoxLayout]
+    default: QtWidgets.QVBoxLayout
+    options: [QtWidgets.QHBoxLayout, QtWidgets.QVBoxLayout]
     option_labels: [Horizontal, Vertical]
     hide: ${ ('part' if widget == 'radio_buttons' else 'all') }
 -   id: gui_hint
@@ -148,9 +148,9 @@ templates:
         <%
             win = 'self._%s_tool_bar'%id
         %>\
-        ${win} = Qt.QToolBar(self)
-        ${win}.addWidget(Qt.QLabel("${no_quotes(label,repr(id))}" + ": "))
-        self._${id}_combo_box = Qt.QComboBox()
+        ${win} = QtWidgets.QToolBar(self)
+        ${win}.addWidget(QtWidgets.QLabel("${no_quotes(label,repr(id))}" + ": "))
+        self._${id}_combo_box = QtWidgets.QComboBox()
         ${win}.addWidget(self._${id}_combo_box)
         for _label in self._${id}_labels: self._${id}_combo_box.addItem(_label)
         self._${id}_callback = lambda i: QtCore.QMetaObject.invokeMethod(self._${id}_combo_box, "setCurrentIndex", QtCore.Q_ARG("int", self._${id}_options.index(i)))
@@ -163,24 +163,24 @@ templates:
         <%
             win = 'self._%s_group_box'%id
         %>\
-        ${win} = Qt.QGroupBox("${no_quotes(label,repr(id))}" + ": ")
+        ${win} = QtWidgets.QGroupBox("${no_quotes(label,repr(id))}" + ": ")
         self._${id}_box = ${orient}()
-        class variable_chooser_button_group(Qt.QButtonGroup):
+        class variable_chooser_button_group(QtWidgets.QButtonGroup):
             def __init__(self, parent=None):
-                Qt.QButtonGroup.__init__(self, parent)
+                QtWidgets.QButtonGroup.__init__(self, parent)
             @pyqtSlot(int)
             def updateButtonChecked(self, button_id):
                 self.button(button_id).setChecked(True)
         self._${id}_button_group = variable_chooser_button_group()
         ${win}.setLayout(self._${id}_box)
         for i, _label in enumerate(self._${id}_labels):
-            radio_button = Qt.QRadioButton(_label)
+            radio_button = QtWidgets.QRadioButton(_label)
             self._${id}_box.addWidget(radio_button)
             self._${id}_button_group.addButton(radio_button, i)
         self._${id}_callback = lambda i: QtCore.QMetaObject.invokeMethod(self._${id}_button_group, "updateButtonChecked", QtCore.Q_ARG("int", self._${id}_options.index(i)))
         self._${id}_callback(self.${id})
-        self._${id}_button_group.buttonClicked[int].connect(
-            lambda i: self.set_${id}(self._${id}_options[i]))
+        self._${id}_button_group.buttonClicked.connect(
+            lambda i: self.set_${id}(self._${id}_options[self._${id}_button_group.id(i)]))
         % endif
         ${gui_hint() % win}
 

--- a/gr-qtgui/grc/qtgui_entry.block.yml
+++ b/gr-qtgui/grc/qtgui_entry.block.yml
@@ -46,9 +46,9 @@ templates:
         <%
             win = 'self._%s_tool_bar'%id
         %>
-        ${win} = QToolBar(self)
-        ${win}.addWidget(QLabel("${no_quotes(label,repr(id))}" + ": "))
-        self._${id}_line_edit = QLineEdit(str(self.${id}))
+        ${win} = QtWidgets.QToolBar(self)
+        ${win}.addWidget(QtWidgets.QLabel("${no_quotes(label,repr(id))}" + ": "))
+        self._${id}_line_edit = QtWidgets.QLineEdit(str(self.${id}))
         self._${id}_tool_bar.addWidget(self._${id}_line_edit)
         self._${id}_line_edit.${entry_signal}.connect(
             lambda: self.set_${id}(${type.conv}(str(self._${id}_line_edit.text()))))

--- a/gr-qtgui/grc/qtgui_label.block.yml
+++ b/gr-qtgui/grc/qtgui_label.block.yml
@@ -44,15 +44,15 @@ templates:
         <%
             win = 'self._%s_tool_bar'%id
         %>\
-        ${win} = Qt.QToolBar(self)
+        ${win} = QtWidgets.QToolBar(self)
 
         if ${formatter}:
             self._${id}_formatter = ${formatter}
         else:
             self._${id}_formatter = lambda x: ${type.str}(x)
 
-        ${win}.addWidget(Qt.QLabel("${no_quotes(label,repr(id))}"))
-        self._${id}_label = Qt.QLabel(str(self._${id}_formatter(self.${id})))
+        ${win}.addWidget(QtWidgets.QLabel("${no_quotes(label,repr(id))}"))
+        self._${id}_label = QtWidgets.QLabel(str(self._${id}_formatter(self.${id})))
         self._${id}_tool_bar.addWidget(self._${id}_label)
         ${gui_hint() % win}
 

--- a/gr-qtgui/grc/qtgui_push_button.block.yml
+++ b/gr-qtgui/grc/qtgui_push_button.block.yml
@@ -42,8 +42,8 @@ templates:
         <%
             win = '_%s_push_button'%id
         %>\
-        ${win} = Qt.QPushButton(${label})
-        ${win} = Qt.QPushButton(${(label if (len(label) - 2 > 0) else repr(id))})
+        ${win} = QtWidgets.QPushButton(${label})
+        ${win} = QtWidgets.QPushButton(${(label if (len(label) - 2 > 0) else repr(id))})
         self._${id}_choices = {'Pressed': ${pressed}, 'Released': ${released}}
         ${win}.pressed.connect(lambda: self.set_${id}(self._${id}_choices['Pressed']))
         ${win}.released.connect(lambda: self.set_${id}(self._${id}_choices['Released']))

--- a/gr-qtgui/grc/qtgui_tab_widget.block.yml
+++ b/gr-qtgui/grc/qtgui_tab_widget.block.yml
@@ -123,11 +123,11 @@ templates:
                           label10, label11, label12, label13, label14,
                           label15, label16, label17, label18, label19][:int(num_tabs)]
         %>\
-        Qt.QTabWidget()
+        QtWidgets.QTabWidget()
         % for i, label in enumerate(all_labels):
         self.${id}_widget_${i} = QtWidgets.QWidget()
-        self.${id}_layout_${i} = Qt.QBoxLayout(Qt.QBoxLayout.Direction.TopToBottom, self.${id}_widget_${i})
-        self.${id}_grid_layout_${i} = Qt.QGridLayout()
+        self.${id}_layout_${i} = QtWidgets.QBoxLayout(QtWidgets.QBoxLayout.Direction.TopToBottom, self.${id}_widget_${i})
+        self.${id}_grid_layout_${i} = QtWidgets.QGridLayout()
         self.${id}_layout_${i}.addLayout(self.${id}_grid_layout_${i})
         ${win}.addTab(self.${id}_widget_${i}, ${label})
         % endfor

--- a/gr-qtgui/python/qtgui/compass.py
+++ b/gr-qtgui/python/qtgui/compass.py
@@ -152,7 +152,7 @@ class Compass(QWidget):
 
             if i % 45 == 0:
                 painter.drawLine(0, -40, 0, -50)
-                painter.drawText(int(-metrics.width(
+                painter.drawText(int(-metrics.horizontalAdvance(
                     self._pointText[i]) / 2.0), -52, self._pointText[i])
             else:
                 painter.drawLine(0, -45, 0, -50)

--- a/gr-qtgui/python/qtgui/digitalnumbercontrol.py
+++ b/gr-qtgui/python/qtgui/digitalnumbercontrol.py
@@ -124,7 +124,7 @@ class DigitalNumberControl(QFrame):
         else:
             textstr = teststr
 
-        width = fm.width(textstr)
+        width = fm.horizontalAdvance(textstr)
 
         self.minwidth = width
 
@@ -161,7 +161,7 @@ class DigitalNumberControl(QFrame):
         else:
             textstr = str(self.getFrequency())
 
-        width = fm.width(textstr)
+        width = fm.horizontalAdvance(textstr)
 
         # So we know:
         # - the width of the text
@@ -173,9 +173,9 @@ class DigitalNumberControl(QFrame):
         found_number = False
         clicked_thousands = False
         for i in range(1, len(textstr) + 1):
-            width = fm.width(textstr[-i:])
+            width = fm.horizontalAdvance(textstr[-i:])
             charstr = textstr[-i:]
-            widthchar = fm.width(charstr[0])
+            widthchar = fm.horizontalAdvance(charstr[0])
             if clickpos >= (width - widthchar) and clickpos <= width:
                 clicked_char = i - 1
 

--- a/gr-qtgui/python/qtgui/ledindicator.py
+++ b/gr-qtgui/python/qtgui/ledindicator.py
@@ -72,7 +72,7 @@ class LabeledLEDIndicator(QFrame):
             textfont = self.lblcontrol.font()
             metrics = QFontMetricsF(textfont)
 
-            maxWidth = int(max((maxSize + 30), (maxSize + metrics.width(lbl) + 4)))
+            maxWidth = int(max((maxSize + 30), (maxSize + metrics.horizontalAdvance(lbl) + 4)))
             maxHeight = int(max((maxSize + 35), (maxSize + metrics.height() + 2)))
             self.setMinimumSize(maxWidth, maxHeight)
         else:

--- a/gr-qtgui/python/qtgui/toggleswitch.py
+++ b/gr-qtgui/python/qtgui/toggleswitch.py
@@ -75,7 +75,7 @@ class LabeledToggleSwitch(QFrame):
         textfont = self.lblcontrol.font()
         metrics = QFontMetricsF(textfont)
 
-        maxWidth = max((maxSize + 4), (maxSize * 2 + metrics.width(lbl)))
+        maxWidth = max((maxSize + 4), (maxSize * 2 + metrics.horizontalAdvance(lbl)))
         maxHeight = max((maxSize // 2 + 4),
                         (maxSize // 2 + metrics.height() + 2))
 
@@ -146,7 +146,7 @@ class ToggleSwitch(QFrame):
             painter.drawEllipse(2, 2, size.height() - 4, size.height() - 4)
 
     def mousePressEvent(self, event):
-        if event.x() <= self.size().width() / 2:
+        if event.position().x() <= self.size().width() / 2:
             self.setState(False)
         else:
             self.setState(True)


### PR DESCRIPTION
Tested your qt5to6 branch on Gentoo distro with Python3.14 and Qt/PyQt 6.11.

Some of the GUI Widgets (input ones) failed at runtime with ' name "Qt" not found' or similar problems.

Among the problematic blocks are:
 * Qt Checkbox
 * Qt Chooser
 * Qt DigitalNumberControl
 * Qt Entry
 * Qt Label
 * Qt LED
 * Qt Push Button
 * Qt ToggleSwitch

I did some rough changes to fix the problems here. In most cases a replacement of 'Qt' by 'QtWidgets' did the trick. Second common problems was the changed syntax for getting the string with for a given QMetricFont (switch from '.width' to '.horizontalAdvance'). For further details see the diifs.

Be aware that I did only care for Python generation.